### PR TITLE
Feature/tame run times

### DIFF
--- a/native/compile.sh
+++ b/native/compile.sh
@@ -5,4 +5,5 @@ if test "$#" -ne 2; then
     exit 1
 fi
 
-icc -m64 -fPIC -fp-model strict -O3 -g -fomit-frame-pointer -qopenmp -xSSE4.2 -axCORE-AVX2,COMMON-AVX512 -lmkl_rt "$1" -o "$2"
+icc -m64 -fPIC -fp-model strict -O3 -g -fomit-frame-pointer -DNDEBUG -qopenmp -xSSE4.2 -axCORE-AVX2,COMMON-AVX512 -lmkl_rt "$1" -o "$2"
+

--- a/native/compile.sh
+++ b/native/compile.sh
@@ -5,4 +5,4 @@ if test "$#" -ne 2; then
     exit 1
 fi
 
-icc -m64 -fPIC -fp-model strict -O3 -g -fomit-frame-pointer -qopenmp -xSSE4.2 -axCORE-AVX2,CORE-AVX512 -lmkl_rt "$1" -o "$2"
+icc -m64 -fPIC -fp-model strict -O3 -g -fomit-frame-pointer -qopenmp -xSSE4.2 -axCORE-AVX2,COMMON-AVX512 -lmkl_rt "$1" -o "$2"

--- a/native/fft2_cdp-in-c.c
+++ b/native/fft2_cdp-in-c.c
@@ -86,8 +86,8 @@ int main() {
         status = DftiCommitDescriptor(hand);
         assert(status == 0);
 
-        status = DftiSetValue(hand, DFTI_COMPLEX_STORAGE, DFTI_COMPLEX_COMPLEX);
-        assert(status == 0);
+//        status = DftiSetValue(hand, DFTI_COMPLEX_STORAGE, DFTI_COMPLEX_COMPLEX);
+//        assert(status == 0);
 
         t1 = moment_now();
         time_tot += t1 - t0;

--- a/native/fft2_cdp-in-c.c
+++ b/native/fft2_cdp-in-c.c
@@ -86,6 +86,12 @@ int main() {
         status = DftiCommitDescriptor(hand);
         assert(status == 0);
 
+        status = DftiSetValue(hand, DFTI_FORWARD_SCALE, 1.0);
+        assert(status == 0);
+
+        status = DftiSetValue(hand, DFTI_BACKWARD_SCALE, 1.0/(N1 * N2));
+        assert(status == 0);
+
 //        status = DftiSetValue(hand, DFTI_COMPLEX_STORAGE, DFTI_COMPLEX_COMPLEX);
 //        assert(status == 0);
 

--- a/native/fft2_cdp-in-nc.c
+++ b/native/fft2_cdp-in-nc.c
@@ -68,9 +68,9 @@ int main() {
 
     warm_up_threads();
 
-    for(si=0; si < samps; time_tot=0, si++) {
+    for(si=0; si < samps; si++) {
 
-        for(it = -1; it <reps;  it++) {
+        for(time_tot=0, it = -1; it <reps;  it++) {
 
            cblas_zcopy(N, (void *) x, 1, (void *) buf, 1); /* buf = x */
            /* memcpy(buf, x, N*sizeof(MKL_Complex16)); */
@@ -86,6 +86,12 @@ int main() {
             assert(status == 0);
 
             status = DftiSetValue(hand, DFTI_INPUT_STRIDES, strides);
+            assert(status == 0);
+
+            status = DftiSetValue(hand, DFTI_FORWARD_SCALE, 1.0);
+            assert(status == 0);
+
+            status = DftiSetValue(hand, DFTI_BACKWARD_SCALE, 1.0/(N1 * N2));
             assert(status == 0);
 
             status = DftiCommitDescriptor(hand);

--- a/native/fft2_cdp-in-nc.c
+++ b/native/fft2_cdp-in-nc.c
@@ -88,9 +88,6 @@ int main() {
             status = DftiSetValue(hand, DFTI_INPUT_STRIDES, strides);
             assert(status == 0);
 
-            status = DftiSetValue(hand, DFTI_COMPLEX_STORAGE, DFTI_COMPLEX_COMPLEX);
-            assert(status == 0);
-
             status = DftiCommitDescriptor(hand);
             assert(status == 0);
 

--- a/native/fft2_cdp-out-c.c
+++ b/native/fft2_cdp-out-c.c
@@ -87,6 +87,12 @@ int main() {
         status = DftiSetValue(hand, DFTI_OUTPUT_STRIDES, strides);
         assert(status == 0);
 
+        status = DftiSetValue(hand, DFTI_FORWARD_SCALE, 1.0);
+        assert(status == 0);
+
+        status = DftiSetValue(hand, DFTI_BACKWARD_SCALE, 1.0/(N1 * N2));
+        assert(status == 0);
+
         status = DftiCommitDescriptor(hand);
         assert(status == 0);
 

--- a/native/fft2_cdp-out-nc.c
+++ b/native/fft2_cdp-out-nc.c
@@ -89,6 +89,12 @@ int main() {
             status = DftiSetValue(hand, DFTI_OUTPUT_STRIDES, strides);
             assert(status == 0);
 
+            status = DftiSetValue(hand, DFTI_FORWARD_SCALE, 1.0);
+            assert(status == 0);
+
+            status = DftiSetValue(hand, DFTI_BACKWARD_SCALE, 1.0/(N1 * N2));
+            assert(status == 0);
+
             status = DftiCommitDescriptor(hand);
             assert(status == 0);
 

--- a/native/fft3_cdp-in-c.c
+++ b/native/fft3_cdp-in-c.c
@@ -79,6 +79,12 @@ int main() {
         status = DftiSetValue(hand, DFTI_INPUT_STRIDES, strides);
         assert(status == 0);
 
+        status = DftiSetValue(hand, DFTI_FORWARD_SCALE, 1.0);
+        assert(status == 0);
+
+        status = DftiSetValue(hand, DFTI_BACKWARD_SCALE, 1.0/(N1 * N2 * N3));
+        assert(status == 0);
+
         status = DftiCommitDescriptor(hand);
         assert(status == 0);
 

--- a/native/fft3_cdp-in-nc.c
+++ b/native/fft3_cdp-in-nc.c
@@ -89,6 +89,13 @@ int main() {
             status = DftiSetValue(hand, DFTI_INPUT_STRIDES, strides);
             assert(status == 0);
 
+            status = DftiSetValue(hand, DFTI_FORWARD_SCALE, 1.0);
+            assert(status == 0);
+
+            status = DftiSetValue(hand, DFTI_BACKWARD_SCALE, 1.0/(N1 * N2 * N3));
+            assert(status == 0);
+
+
             status = DftiCommitDescriptor(hand);
             assert(status == 0);
 

--- a/native/fft3_cdp-out-c.c
+++ b/native/fft3_cdp-out-c.c
@@ -83,6 +83,12 @@ int main() {
         status = DftiSetValue(hand, DFTI_OUTPUT_STRIDES, strides);
         assert(status == 0);
 
+        status = DftiSetValue(hand, DFTI_FORWARD_SCALE, 1.0);
+        assert(status == 0);
+
+        status = DftiSetValue(hand, DFTI_BACKWARD_SCALE, 1.0/(N1 * N2 * N3));
+        assert(status == 0);
+
         status = DftiCommitDescriptor(hand);
         assert(status == 0);
 

--- a/native/fft3_cdp-out-nc.c
+++ b/native/fft3_cdp-out-nc.c
@@ -90,6 +90,12 @@ int main() {
             status = DftiSetValue(hand, DFTI_OUTPUT_STRIDES, strides);
             assert(status == 0);
 
+            status = DftiSetValue(hand, DFTI_FORWARD_SCALE, 1.0);
+            assert(status == 0);
+
+            status = DftiSetValue(hand, DFTI_BACKWARD_SCALE, 1.0/(N1 * N2 * N3));
+            assert(status == 0);
+
             status = DftiCommitDescriptor(hand);
             assert(status == 0);
 

--- a/python/perf.py
+++ b/python/perf.py
@@ -77,12 +77,18 @@ def time_func(func, arg_array, keywords, batch_size=16, repetitions=24, refresh_
     # warm-up
     gc.collect()
     gc.disable()
+    t0 = now()
     f = func(buf, **keywords)
+    t1 = now()
+    time_tot = time_delta(t0, t1)
+    actual_batch_size = batch_size
+    if time_tot * batch_size > 5:
+        actual_batch_size = 1 + int(5/time_tot)
     # start measurements
     for i in range(repetitions):
         time_tot = 0
         if refresh_buffer:
-            for _ in range(batch_size):
+            for _ in range(actual_batch_size):
                 np.copyto(buf, arg_array)
                 t0 = now()
                 f = func(buf, **keywords)
@@ -90,12 +96,12 @@ def time_func(func, arg_array, keywords, batch_size=16, repetitions=24, refresh_
                 time_tot += time_delta(t0, t1)
         else:
             t0 = now()
-            for _ in range(batch_size):
+            for _ in range(actual_batch_size):
                 f = func(buf, **keywords)
             t1 = now()
             time_tot += time_delta(t0, t1)
         #
-        times_list[i] = time_tot
+        times_list[i] = (time_tot/actual_batch_size) * batch_size
     gc.enable()
     return times_list
 

--- a/python/run_fft_native.py
+++ b/python/run_fft_native.py
@@ -113,7 +113,7 @@ def update_envs(st_dict, update_dict):
     res.update(update_dict)
     return res
 
-def native_perf_times(exec, pars, repetitions=24):
+def native_perf_times(exec, pars, repetitions=6):
     global natives_dir
     header = ['=' * 10 + ' ' + exec + ' ' + '=' * 10]
     perfs = []
@@ -154,17 +154,17 @@ print("$PREFIX = %s" % prefix)
 if IS_WIN:
     # inherenting from the environment allows native code to see MKL
     common_env_vars = environ.copy()
-    common_env_vars.update({'REPS' : '16'})
+    common_env_vars.update({'REPS' : '12'})
     params_1d = {'N' : '1200000'}
     params_2d = {'N1' : '1200', 'N2' : '1200'}
     params_3d = {'N1' : '113', 'N2' : '114', 'N3' : '115'}
 else:
     common_env_vars = update_envs(environ, {
         'LD_LIBRARY_PATH' : prefix + '/lib' + ':' + environ.get('LD_LIBRARY_PATH', default=''),
-        'REPS' : '16', })
-    params_1d = {'N' : '25000000'}
-    params_2d = {'N1' : '5000', 'N2' : '5000'}
-    params_3d = {'N1' : '313', 'N2' : '314', 'N3' : '315'}
+        'REPS' : '16'})
+    params_1d = {'N' : '5000000'}
+    params_2d = {'N1' : '2500', 'N2' : '2500'}
+    params_3d = {'N1' : '113', 'N2' : '214', 'N3' : '315'}
 
 header, perf_times = native_perf_times('fft_cdp-out-c.exe', params_1d)
 print_info(header, perf_times)

--- a/python/run_fft_python.py
+++ b/python/run_fft_python.py
@@ -13,9 +13,9 @@ if system() == 'Windows':
    n2d = 1200
    size3d = (113, 114, 115)
 else:
-   n1d = 25*(10**6)
-   n2d = 5000
-   size3d = (313, 314, 315)
+   n1d = 5*(10**6)
+   n2d = 2500
+   size3d = (113, 214, 315)
 
 rs = get_random_state()
 
@@ -40,7 +40,7 @@ print("", flush=True)
 
 tf_kw = {'batch_size': 16, 'repetitions': 6}
 
-perf_times = time_func(np.fft.fft, vec_z, dict(), **tf_kw)
+perf_times = time_func(np.fft.fft, vec_z, dict(), refresh_buffer=False, **tf_kw)
 print_summary(perf_times, header='np.fft.fft' + arg_signature(vec_z))
 
 if run_scipy:
@@ -48,7 +48,7 @@ if run_scipy:
     print_summary(perf_times, header='scipy.fftpack.fft, overwrite_x=True' + arg_signature(vec_z))
 
 
-perf_times = time_func(np.fft.fft2, mat_z, dict(), **tf_kw)
+perf_times = time_func(np.fft.fft2, mat_z, dict(), refresh_buffer=False, **tf_kw)
 print_summary(perf_times, header='np.fft.fft2' + arg_signature(mat_z))
 
 if run_scipy:
@@ -57,7 +57,7 @@ if run_scipy:
     print_summary(perf_times, header='scipy.fftpack.fft2, overwrite_x=True' + arg_signature(mat_z))
 
 
-perf_times = time_func(np.fft.fftn, arr_z, dict(), **tf_kw)
+perf_times = time_func(np.fft.fftn, arr_z, dict(), refresh_buffer=False, **tf_kw)
 print_summary(perf_times, header='np.fft.fftn' + arg_signature(arr_z))
 
 if run_scipy:

--- a/python/run_fft_python.py
+++ b/python/run_fft_python.py
@@ -38,27 +38,29 @@ del buf
 
 print("", flush=True)
 
-perf_times = time_func(np.fft.fft, vec_z, dict())
+tf_kw = {'batch_size': 16, 'repetitions': 6}
+
+perf_times = time_func(np.fft.fft, vec_z, dict(), **tf_kw)
 print_summary(perf_times, header='np.fft.fft' + arg_signature(vec_z))
 
 if run_scipy:
-    perf_times = time_func(scipy.fftpack.fft, vec_z, dict(overwrite_x=True))
+    perf_times = time_func(scipy.fftpack.fft, vec_z, dict(overwrite_x=True), **tf_kw)
     print_summary(perf_times, header='scipy.fftpack.fft, overwrite_x=True' + arg_signature(vec_z))
 
 
-perf_times = time_func(np.fft.fft2, mat_z, dict())
+perf_times = time_func(np.fft.fft2, mat_z, dict(), **tf_kw)
 print_summary(perf_times, header='np.fft.fft2' + arg_signature(mat_z))
 
 if run_scipy:
     # Benchmarking scipy.fftpack
-    perf_times = time_func(scipy.fftpack.fft2, mat_z, dict(overwrite_x=True))
+    perf_times = time_func(scipy.fftpack.fft2, mat_z, dict(overwrite_x=True), **tf_kw)
     print_summary(perf_times, header='scipy.fftpack.fft2, overwrite_x=True' + arg_signature(mat_z))
 
 
-perf_times = time_func(np.fft.fftn, arr_z, dict())
+perf_times = time_func(np.fft.fftn, arr_z, dict(), **tf_kw)
 print_summary(perf_times, header='np.fft.fftn' + arg_signature(arr_z))
 
 if run_scipy:
-    perf_times = time_func(scipy.fftpack.fftn, arr_z, dict(overwrite_x=True))
+    perf_times = time_func(scipy.fftpack.fftn, arr_z, dict(overwrite_x=True), **tf_kw)
     print_summary(perf_times, header='scipy.fftpack.fftn, overwrite_x=True' + arg_signature(arr_z))
 


### PR DESCRIPTION
1. Adjusted architecture flag when compiling native C benchmarks for FFT to use ``COMMON-AVX512``, rather than ``CORE-AVX512``. See [reference](https://software.intel.com/en-us/articles/performance-tools-for-software-developers-intel-compiler-options-for-sse-generation-and-processor-specific-optimizations).

2. Default choice of 16 runs per batch with 24 repetitions of batch runs, combined with slow performance of FFT in stock NumPy/SciPy, results is excessive run-times for benchmarks of open source stack. Therefore, lowered default 24 repetitions to 6, and added code that would dynamically lower batch size if the batch run time exceeds 5, and rescale the timing to what it would have been should the request batch size was used.

@anton-malakhov @rscohn2 