### PR TITLE
Add rfft native benchmarks, report means

### DIFF
--- a/native/Makefile
+++ b/native/Makefile
@@ -1,5 +1,6 @@
 BENCHMARKS = fft_cdp-in-c fft_cdp-in-nc fft_cdp-out-c \
 			 fft_cdp-out-nc fft_rdp-out-c fft_rdp-out-nc \
+			 rfft_rdp-out-c rfft_rdp-out-nc \
 			 fft_rdp2-out-c fft2_cdp-in-c fft2_cdp-in-nc \
 			 fft3_cdp-in-c fft3_cdp-in-nc fft2_cdp-out-c \
 			 fft2_cdp-out-nc fft3_cdp-out-c fft3_cdp-out-nc

--- a/native/fft_rdp-out-nc.c
+++ b/native/fft_rdp-out-nc.c
@@ -40,7 +40,7 @@ int main() {
 
     warm_up_threads();
 
-    for(si=0; si < samps; time_tot=0, si++) {
+    for(si = 0; si < samps; time_tot=0, si++) {
         for(it = -1; it <reps;  it++) {
             long k_dest;
 
@@ -87,10 +87,11 @@ int main() {
 
 #include "print_buf.inc"
 
-    mkl_free(buf);
     err = vslDeleteStream(&stream);
     assert(err == VSL_STATUS_OK);
 
+    mkl_free(buf);
     mkl_free(x);
+
     return 0;
 }

--- a/native/rfft_rdp-out-c.c
+++ b/native/rfft_rdp-out-c.c
@@ -71,14 +71,6 @@ int main() {
             status = DftiComputeForward(hand, x, buf);
             assert(status == 0);
 
-            // copy superfluous harmonics
-#pragma omp parallel for simd
-            for (k_dest = N/2 + 1; k_dest < N; k_dest++) {
-                long k_src = (N - k_dest) % N;
-                buf[k_dest].real = buf[k_src].real;
-                buf[k_dest].imag = -buf[k_src].imag;
-            }
-
             t1 = moment_now();
 
             if (it >= 0) time_tot += t1 - t0;

--- a/python/perf.py
+++ b/python/perf.py
@@ -101,7 +101,7 @@ def time_func(func, arg_array, keywords, batch_size=16, repetitions=24, refresh_
             t1 = now()
             time_tot += time_delta(t0, t1)
         #
-        times_list[i] = (time_tot/actual_batch_size) * batch_size
+        times_list[i] = time_tot / actual_batch_size
     gc.enable()
     return times_list
 

--- a/python/run_fft_native.py
+++ b/python/run_fft_native.py
@@ -170,6 +170,8 @@ parser.add_argument('-p', '--overwrite-x', default=False, action='store_true',
                     help='Allow overwriting input array')
 parser.add_argument('-s', '--shape', default=None,
                     help='FFT shape, dimensions separated by comma')
+parser.add_argument('-d', '--domain', default='complex',
+                    choices=['real', 'complex'])
 parser.add_argument('-c', '--cached', default=False, action='store_true',
                     help='Set this option for 1D FFT')
 parser.add_argument('-P', '--path', default=None, help='Path to FFT bench binaries')
@@ -192,8 +194,8 @@ if args.shape is not None:
 
 in_place = 'in' if args.overwrite_x else 'out'
 cached = 'c' if args.cached else 'nc'
-domain = 'r' if args.type == 'rfft' else 'c'
-problem = 'fft' if args.type == 'rfft' else args.type
+domain = 'r' if args.type == 'rfft' else args.domain[0]
+problem = args.type
 exe_name = f'{problem}_{domain}dp-{in_place}-{cached}.exe'
 
 if args.path:
@@ -203,10 +205,12 @@ if args.path:
         exe_name = args.path
 
 params = {
+    'rfft': params_1d,
     'fft': params_1d,
     'fft2': params_2d,
     'fft3': params_3d
 }
 header, perf_times = native_perf_times(exe_name, params[problem])
+perf_times /= int(common_env_vars.get('REPS'))
 print_info(header, perf_times)
 


### PR DESCRIPTION
Turns out `fft_rdp-out-{c,nc}.c` are actually benchmarks equivalent to running `np.fft.fft` on real input, so they make sure to fill the entire output vector, which is the same size as the input. However, `np.fft.rfft` actually only provides the first half of this output vector, so we now have `rfft_rdp-out-{c,nc}.c` to imitate this behavior.

- Add native benchmarks actually equivalent to `np.fft.rfft`
- Change from reporting total time in N (=16) repetitions to reporting the mean, so we can change the number of repetitions between implementations