### PR TITLE
out-of-place native FFT: move buffer alloc inside timing

### DIFF
--- a/native/Makefile
+++ b/native/Makefile
@@ -1,14 +1,14 @@
 BENCHMARKS = fft_cdp-in-c fft_cdp-in-nc fft_cdp-out-c \
-			 fft_cdp-out-nc fft_rdp-out-c fft_rdp-out-nc \
-			 rfft_rdp-out-c rfft_rdp-out-nc \
-			 fft_rdp2-out-c fft2_cdp-in-c fft2_cdp-in-nc \
-			 fft3_cdp-in-c fft3_cdp-in-nc fft2_cdp-out-c \
-			 fft2_cdp-out-nc fft3_cdp-out-c fft3_cdp-out-nc
+	     fft_cdp-out-nc fft_rdp-out-c fft_rdp-out-nc \
+	     rfft_rdp-out-c rfft_rdp-out-nc \
+	     fft_rdp2-out-c fft2_cdp-in-c fft2_cdp-in-nc \
+	     fft3_cdp-in-c fft3_cdp-in-nc fft2_cdp-out-c \
+	     fft2_cdp-out-nc fft3_cdp-out-c fft3_cdp-out-nc
 
 CC = icc
 CFLAGS = -m64 -fPIC -fp-model strict -O3 -g -fomit-frame-pointer \
-		 -DNDEBUG -qopenmp -xSSE4.2 -axCORE-AVX2,COMMON-AVX512 \
-		 -lmkl_rt
+	 -DNDEBUG -qopenmp -xSSE4.2 -axCORE-AVX2,COMMON-AVX512 \
+	 -lmkl_rt
 
 CINCLUDE := $(addprefix -I,$(CINCLUDE))
 

--- a/native/fft2_cdp-out-c.c
+++ b/native/fft2_cdp-out-c.c
@@ -59,14 +59,14 @@ int main() {
     mkl_free(re_vec);
     mkl_free(im_vec);
 
-    buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
-    assert(buf);
-
     warm_up_threads();
 
     for(si=0; si < samps; time_tot=0, si++) {
 
         t0 = moment_now();
+
+        buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
+        assert(buf);
 
         status = DftiCreateDescriptor(
             &hand,
@@ -115,15 +115,13 @@ int main() {
         status = DftiFreeDescriptor(&hand);
         assert(status == 0);
 
+        mkl_free(buf);
+
         t1 = moment_now();
         time_tot += t1 - t0;
 
         printf("%.5g\n", seconds_from_moment(time_tot));
     }
-
-#include "print_buf.inc"
-
-    mkl_free(buf);
 
     err = vslDeleteStream(&stream);
     assert(err == VSL_STATUS_OK);

--- a/native/fft2_cdp-out-c.c
+++ b/native/fft2_cdp-out-c.c
@@ -115,6 +115,10 @@ int main() {
         status = DftiFreeDescriptor(&hand);
         assert(status == 0);
 
+        if (si == 0) {
+#include "print_buf.inc"
+        }
+
         mkl_free(buf);
 
         t1 = moment_now();

--- a/native/fft2_cdp-out-nc.c
+++ b/native/fft2_cdp-out-nc.c
@@ -104,6 +104,10 @@ int main() {
             status = DftiFreeDescriptor(&hand);
             assert(status == 0);
 
+            if (si == 0 && it == -1) {
+#include "print_buf.inc"
+            }
+
             mkl_free(buf);
 
             t1 = moment_now();

--- a/native/fft2_cdp-out-nc.c
+++ b/native/fft2_cdp-out-nc.c
@@ -63,15 +63,15 @@ int main() {
     strides[1] = N2;
     strides[2] = 1;
 
-    buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
-    assert(buf);
-
     warm_up_threads();
 
     for(si=0; si < samps; time_tot=0, si++) {
 
         for(it = -1; it <reps;  it++) {
             t0 = moment_now();
+
+            buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
+            assert(buf);
 
             status = DftiCreateDescriptor(
                 &hand,
@@ -104,6 +104,8 @@ int main() {
             status = DftiFreeDescriptor(&hand);
             assert(status == 0);
 
+            mkl_free(buf);
+
             t1 = moment_now();
 
             if (it >= 0) time_tot += t1 - t0;
@@ -111,10 +113,6 @@ int main() {
 
         printf("%.5g\n", seconds_from_moment(time_tot));
     }
-
-#include "print_buf.inc"
-
-    mkl_free(buf);
 
     err = vslDeleteStream(&stream);
     assert(err == VSL_STATUS_OK);

--- a/native/fft3_cdp-out-c.c
+++ b/native/fft3_cdp-out-c.c
@@ -115,15 +115,17 @@ int main() {
         status = DftiFreeDescriptor(&hand);
         assert(status == 0);
 
+        if (si == 0) {
+#include "print_buf.inc"
+        }
+
+        mkl_free(buf);
+
         t1 = moment_now();
         time_tot += t1 - t0;
 
         printf("%.5g\n", seconds_from_moment(time_tot));
     }
-
-#include "print_buf.inc"
-
-    mkl_free(buf);
 
     err = vslDeleteStream(&stream);
     assert(err == VSL_STATUS_OK);

--- a/native/fft3_cdp-out-nc.c
+++ b/native/fft3_cdp-out-nc.c
@@ -105,6 +105,10 @@ int main() {
             status = DftiFreeDescriptor(&hand);
             assert(status == 0);
 
+            if (si == 0 && it == -1) {
+#include "print_buf.inc"
+            }
+
             mkl_free(buf);
 
             t1 = moment_now();

--- a/native/fft3_cdp-out-nc.c
+++ b/native/fft3_cdp-out-nc.c
@@ -59,9 +59,6 @@ int main() {
     mkl_free(re_vec);
     mkl_free(im_vec);
 
-    buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
-    assert(buf);
-
     strides[0] = 0;
     strides[1] = N3 * N2;
     strides[2] = N3;
@@ -74,6 +71,9 @@ int main() {
         for(it = -1; it <reps;  it++) {
 
             t0 = moment_now();
+
+            buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
+            assert(buf);
 
             status = DftiCreateDescriptor(
                 &hand,
@@ -105,16 +105,14 @@ int main() {
             status = DftiFreeDescriptor(&hand);
             assert(status == 0);
 
+            mkl_free(buf);
+
             t1 = moment_now();
             if(it >= 0) time_tot += t1 - t0;
         }
 
         printf("%.5g\n", seconds_from_moment(time_tot));
     }
-
-#include "print_buf.inc"
-
-    mkl_free(buf);
 
     err = vslDeleteStream(&stream);
     assert(err == VSL_STATUS_OK);

--- a/native/fft_cdp-out-c.c
+++ b/native/fft_cdp-out-c.c
@@ -51,14 +51,14 @@ int main() {
     mkl_free(re_vec);
     mkl_free(im_vec);
 
-    buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
-    assert(buf);
-
     warm_up_threads();
 
     for(si=0; si < samps; time_tot=0, si++) {
 
         t0 = moment_now();
+
+        buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
+        assert(buf);
 
         status = DftiCreateDescriptor(
             &hand,
@@ -94,18 +94,17 @@ int main() {
         status = DftiFreeDescriptor(&hand);
         assert(status == 0);
 
+        mkl_free(buf);
+
         t1 = moment_now();
         time_tot += t1 - t0;
 
         printf("%.5g\n", seconds_from_moment(time_tot));
     }
 
-#include "print_buf.inc"
-
     err = vslDeleteStream(&stream);
     assert(err == VSL_STATUS_OK);
 
-    mkl_free(buf);
     mkl_free(x);
 
     return 0;

--- a/native/fft_cdp-out-c.c
+++ b/native/fft_cdp-out-c.c
@@ -94,6 +94,10 @@ int main() {
         status = DftiFreeDescriptor(&hand);
         assert(status == 0);
 
+        if (si == 0) {
+#include "print_buf.inc"
+        }
+
         mkl_free(buf);
 
         t1 = moment_now();

--- a/native/fft_cdp-out-nc.c
+++ b/native/fft_cdp-out-nc.c
@@ -82,6 +82,10 @@ int main() {
             status = DftiFreeDescriptor(&hand);
             assert(status == 0);
 
+            if (si == 0 && it == -1) {
+#include "print_buf.inc"
+            }
+
             mkl_free(buf);
 
             t1 = moment_now();

--- a/native/fft_cdp-out-nc.c
+++ b/native/fft_cdp-out-nc.c
@@ -51,9 +51,6 @@ int main() {
     mkl_free(re_vec);
     mkl_free(im_vec);
 
-    buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
-    assert(buf);
-
     warm_up_threads();
 
     for(si=0; si < samps; time_tot=0, si++) {
@@ -61,6 +58,9 @@ int main() {
         for(it = -1; it <reps;  it++) {
 
             t0 = moment_now();
+
+            buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
+            assert(buf);
 
             status = DftiCreateDescriptor(
                 &hand,
@@ -82,6 +82,8 @@ int main() {
             status = DftiFreeDescriptor(&hand);
             assert(status == 0);
 
+            mkl_free(buf);
+
             t1 = moment_now();
             if (it >= 0) time_tot += t1 - t0;
         }
@@ -89,12 +91,9 @@ int main() {
         printf("%.5g\n", seconds_from_moment(time_tot));
     }
 
-#include "print_buf.inc"
-
     err = vslDeleteStream(&stream);
     assert(err == VSL_STATUS_OK);
 
-    mkl_free(buf);
     mkl_free(x);
 
     return 0;

--- a/native/fft_rdp-out-c.c
+++ b/native/fft_rdp-out-c.c
@@ -35,13 +35,13 @@ int main() {
     err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, stream, N, x, d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
-    buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
-    assert(buf);
-
     warm_up_threads();
 
     for(si = 0; si < samps; time_tot=0, si++) {
         t0 = moment_now();
+
+        buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
+        assert(buf);
 
         status = DftiCreateDescriptor(
             &hand,
@@ -89,6 +89,8 @@ int main() {
         status = DftiFreeDescriptor(&hand);
         assert(status == 0);
 
+        mkl_free(buf);
+
         t1 = moment_now();
         time_tot += t1 - t0;
 
@@ -100,7 +102,6 @@ int main() {
     err = vslDeleteStream(&stream);
     assert(err == VSL_STATUS_OK);
 
-    mkl_free(buf);
     mkl_free(x);
 
     return 0;

--- a/native/fft_rdp-out-c.c
+++ b/native/fft_rdp-out-c.c
@@ -89,6 +89,10 @@ int main() {
         status = DftiFreeDescriptor(&hand);
         assert(status == 0);
 
+        if (si == 0) {
+#include "print_buf.inc"
+        }
+
         mkl_free(buf);
 
         t1 = moment_now();
@@ -96,8 +100,6 @@ int main() {
 
         printf("%.5g\n", seconds_from_moment(time_tot));
     }
-
-#include "print_buf.inc"
 
     err = vslDeleteStream(&stream);
     assert(err == VSL_STATUS_OK);

--- a/native/fft_rdp-out-nc.c
+++ b/native/fft_rdp-out-nc.c
@@ -26,14 +26,14 @@ int main() {
 #define DESCRIPTION_STR "Real double, not in-place, not cached"
 #include "read_n_echo_env.inc"
 
+    x = (double *) mkl_malloc(N * sizeof(double), 64);
+    assert(x);
+
     err = vslNewStream(&stream, VSL_BRNG_MT19937, SEED);
     assert(err == VSL_STATUS_OK);
 
     err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, stream, N, x, d_zero, d_one);
     assert(err == VSL_STATUS_OK);
-
-    buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
-    assert(buf);
 
     warm_up_threads();
 
@@ -43,8 +43,8 @@ int main() {
 
             t0 = moment_now();
 
-            x = (double *) mkl_malloc(N * sizeof(double), 64);
-            assert(x);
+            buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
+            assert(buf);
 
             status = DftiCreateDescriptor(
                 &hand,
@@ -76,6 +76,10 @@ int main() {
 
             status = DftiFreeDescriptor(&hand);
             assert(status == 0);
+
+            if (si == 0 && it == -1) {
+#include "print_buf.inc"
+            }
 
             mkl_free(buf);
 

--- a/native/fft_rdp-out-nc.c
+++ b/native/fft_rdp-out-nc.c
@@ -29,9 +29,6 @@ int main() {
     err = vslNewStream(&stream, VSL_BRNG_MT19937, SEED);
     assert(err == VSL_STATUS_OK);
 
-    x = (double *) mkl_malloc(N * sizeof(double), 64);
-    assert(x);
-
     err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, stream, N, x, d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
@@ -45,6 +42,9 @@ int main() {
             long k_dest;
 
             t0 = moment_now();
+
+            x = (double *) mkl_malloc(N * sizeof(double), 64);
+            assert(x);
 
             status = DftiCreateDescriptor(
                 &hand,
@@ -77,6 +77,8 @@ int main() {
             status = DftiFreeDescriptor(&hand);
             assert(status == 0);
 
+            mkl_free(buf);
+
             t1 = moment_now();
 
             if (it >= 0) time_tot += t1 - t0;
@@ -85,12 +87,9 @@ int main() {
         printf("%.5g\n", seconds_from_moment(time_tot));
     }
 
-#include "print_buf.inc"
-
     err = vslDeleteStream(&stream);
     assert(err == VSL_STATUS_OK);
 
-    mkl_free(buf);
     mkl_free(x);
 
     return 0;

--- a/native/fft_rdp2-out-c.c
+++ b/native/fft_rdp2-out-c.c
@@ -105,6 +105,10 @@ int main() {
         status = DftiFreeDescriptor(&hand);
         assert(status == 0);
 
+        if (si == 0) {
+#include "print_buf.inc"
+        }
+
         mkl_free(buf);
 
         t1 = moment_now();

--- a/native/fft_rdp2-out-c.c
+++ b/native/fft_rdp2-out-c.c
@@ -35,9 +35,6 @@ int main() {
     y = (double *) mkl_malloc(N * sizeof(double), 64);
     assert(y);
 
-    buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
-    assert(buf);
-
     err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, stream, N, x, d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
@@ -46,6 +43,9 @@ int main() {
     for(si=0; si < samps; time_tot=0, si++) {
 
         t0 = moment_now();
+
+        buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
+        assert(buf);
 
         status = DftiCreateDescriptor(
             &hand,
@@ -105,18 +105,17 @@ int main() {
         status = DftiFreeDescriptor(&hand);
         assert(status == 0);
 
+        mkl_free(buf);
+
         t1 = moment_now();
         time_tot += t1 - t0;
 
         printf("%.5g\n", seconds_from_moment(time_tot));
     }
 
-#include "print_buf.inc"
-
     err = vslDeleteStream(&stream);
     assert(err == VSL_STATUS_OK);
 
-    mkl_free(buf);
     mkl_free(y);
     mkl_free(x);
 

--- a/native/rfft_rdp-out-c.c
+++ b/native/rfft_rdp-out-c.c
@@ -81,6 +81,10 @@ int main() {
         status = DftiFreeDescriptor(&hand);
         assert(status == 0);
 
+        if (si == 0) {
+#include "print_buf.inc"
+        }
+
         mkl_free(buf);
 
         t1 = moment_now();

--- a/native/rfft_rdp-out-c.c
+++ b/native/rfft_rdp-out-c.c
@@ -35,13 +35,13 @@ int main() {
     err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, stream, N, x, d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
-    buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
-    assert(buf);
-
     warm_up_threads();
 
     for(si = 0; si < samps; time_tot=0, si++) {
         t0 = moment_now();
+
+        buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
+        assert(buf);
 
         status = DftiCreateDescriptor(
             &hand,
@@ -81,18 +81,17 @@ int main() {
         status = DftiFreeDescriptor(&hand);
         assert(status == 0);
 
+        mkl_free(buf);
+
         t1 = moment_now();
         time_tot += t1 - t0;
 
         printf("%.5g\n", seconds_from_moment(time_tot));
     }
 
-#include "print_buf.inc"
-
     err = vslDeleteStream(&stream);
     assert(err == VSL_STATUS_OK);
 
-    mkl_free(buf);
     mkl_free(x);
 
     return 0;

--- a/native/rfft_rdp-out-nc.c
+++ b/native/rfft_rdp-out-nc.c
@@ -35,9 +35,6 @@ int main() {
     err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, stream, N, x, d_zero, d_one);
     assert(err == VSL_STATUS_OK);
 
-    buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
-    assert(buf);
-
     warm_up_threads();
 
     for(si = 0; si < samps; time_tot=0, si++) {
@@ -45,6 +42,9 @@ int main() {
             long k_dest;
 
             t0 = moment_now();
+
+            buf = (MKL_Complex16 *) mkl_malloc(N * sizeof(MKL_Complex16), 64);
+            assert(buf);
 
             status = DftiCreateDescriptor(
                 &hand,
@@ -69,6 +69,12 @@ int main() {
             status = DftiFreeDescriptor(&hand);
             assert(status == 0);
 
+            if (si == 0 && it == -1) {
+#include "print_buf.inc"
+            }
+
+            mkl_free(buf);
+
             t1 = moment_now();
 
             if (it >= 0) time_tot += t1 - t0;
@@ -77,12 +83,9 @@ int main() {
         printf("%.5g\n", seconds_from_moment(time_tot));
     }
 
-#include "print_buf.inc"
-
     err = vslDeleteStream(&stream);
     assert(err == VSL_STATUS_OK);
 
-    mkl_free(buf);
     mkl_free(x);
 
     return 0;


### PR DESCRIPTION
This matches our Python behavior for these benchmarks.