### PR TITLE
Enhancements and Fixes for FFT benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 fft_bench
 *.o
+__pycache__/

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2019, Intel Corporation
+Copyright (c) 2017-2025, Intel Corporation
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2020 Intel Corporation
+# Copyright (c) 2017-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -6,12 +6,13 @@ SOURCES = fft_bench.c
 
 CC = icx
 CFLAGS = -m64 -fPIC -fp-model strict -O3 -g -fomit-frame-pointer \
-	 -DNDEBUG -qopenmp -xSSE4.2 -axCORE-AVX2,CORE-AVX512 \
-	 -lmkl_rt -Wall -pedantic
+         -DNDEBUG -qopenmp -xSSE4.2 -axCORE-AVX2,CORE-AVX512 \
+         -Wall -pedantic
+LDFLAGS = -lmkl_rt
 
 ifneq ($(CONDA_PREFIX),)
-	LDFLAGS += -L$(CONDA_PREFIX)/lib -Wl,-rpath,$(CONDA_PREFIX)/lib
-	CFLAGS += -I$(CONDA_PREFIX)/include
+    LDFLAGS += -L$(CONDA_PREFIX)/lib -Wl,-rpath,$(CONDA_PREFIX)/lib
+    CFLAGS += -I$(CONDA_PREFIX)/include
 endif
 
 all: fft_bench
@@ -21,4 +22,3 @@ clean:
 
 fft_bench: $(SOURCES:.c=.o)
 	$(CC) $^ $(CFLAGS) $(LDFLAGS) -o $@
-

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # FFT benchmarks for NumPy\* and SciPy\*
 
 This FFF benchmarking framework is useful to measure FFT performance of different NumPy and SciPy versions and vendors. 
-In addition to Python implementation we also able to benchmark native code (MKL DFTI) implementations of these benchmarks with similar command-line
-interfaces.
+In addition to Python implementation, it is also possible to benchmark native code (MKL DFTI) implementations of these benchmarks with similar command-line interfaces.
 
 ## Python benchmarks
 
 The following example create benchmarking environment for NumPy and SciPy FFT available from intel channel in conda:
 
 ```bash
-conda create -n intel_env -c intel numpy scipy
-conda activate intel_env
+conda create -n fft_benchmark -c https://software.repos.intel.com/python/conda/ -c conda-forge numpy scipy
+conda activate fft_benchmark
 ```
 
 To run the FFT benchmark framework in Python, type:
@@ -28,47 +27,58 @@ Other printed lines which start with 'TAG: ' are printed for information purpose
 
 ### Examples
 
-Benchmark a 2D out-of-place FFT of a `complex128` array of size `(10000,
-10000)`:
-```
+Benchmark a 2D out-of-place FFT of a `complex128` array of size `(10000, 10000)`:
+
+```bash
 python fft_bench.py 10000x10000
 ```
 
 Benchmark a 1D in-place FFT of a `float32` array of size `100000000`, print
 only 5 measurements, only compute the first half of the conjugate-even
 DFT coefficients, and allow the FFT backend to only use one thread:
-```
+
+```bash
 python fft_bench.py -P -r -t 1 -d float32 -o 5 100000000
 ```
 
 Benchmark a 3D in-place FFT of a `complex64` array of size `1001x203x3005`,
 printing only 5 measurements, each of which average over 24 inner loop
 computations:
-```
+
+```bash
 python fft_bench.py -P -d complex64 -o 5 -i 24 1001x203x3005
 ```
 
 ## Native benchmarks
 
 ### Compiling on Linux
-- To compile, source compiler and run `make`.
-- Run with `./fft_bench`.
+- Source compiler and MKL, then run `make`.
+
+```bash
+source /path_to_oneapi/compiler/latest/env/vars.sh
+source /path_to_oneapi/mkl/latest/env/vars.sh
+make
+```
+
+- Run with `./fft_bench [args] size`.
 
 ### Compiling on Windows
 - Source compiler and MKL, then run `win_compile_all.bat`.
+
   ```
-  > "C:\Program Files (x86)\IntelSWTools\compilers_and_libraries\windows\bin\compilervars.bat intel64"
-  > "C:\Program Files (x86)\IntelSWTools\compilers_and_libraries\windows\mkl\bin\mklvars.bat intel64"
+  > "C:\Program Files (x86)\Intel\oneAPI\compiler\latest\env\vars.bat"
+  > "C:\Program Files (x86)\Intel\oneAPI\mkl\latest\env\vars.bat"
   > win_compile_all.bat
   ```
-- To run, run `fft_bench.exe`. Note that long options are not supported on
+
+- Run with `fft_bench.exe [args] size`. Note that long options are not supported on
   Windows. Use short options instead.
 
 ### Examples
 
-Benchmark a 2D out-of-place FFT of a `complex128` array of size `(10000,
-10000)`:
-```
+Benchmark a 2D out-of-place FFT of a `complex128` array of size `(10000, 10000)`:
+
+```bash
 ./fft_bench 10000x10000
 ```
 
@@ -77,14 +87,16 @@ only 5 measurements, only compute the first half of the conjugate-even
 DFT coefficients, allow the FFT backend to only use one thread, and cache
 the DFTI descriptor between inner loop runs (similar behavior to `mkl_fft` for
 single dimensional FFTs).
-```
+
+```bash
 ./fft_bench -P -c -r -t 1 -d float32 -o 5 100000000
 ```
 
 Benchmark a 3D in-place FFT of a `complex64` array of size `1001x203x3005`,
 printing only 5 measurements, each of which average over 24 inner loop
 computations:
-```
+
+```bash
 ./fft_bench -P -d complex64 -o 5 -i 24 1001x203x3005
 ```
 
@@ -127,7 +139,7 @@ decimal integers, delimited by any non-digit. For example, both
 
 ## See also
 "[Accelerating Scientific Python with Intel
-Optimizations](http://conference.scipy.org/proceedings/scipy2017/pdfs/oleksandr_pavlyk.pdf)"
+Optimizations](https://proceedings.scipy.org/articles/shinma-7f4c6e7-00f)"
 by Oleksandr Pavlyk, Denis Nagorny, Andres Guzman-Ballen, Anton Malakhov, Hai
 Liu, Ehsan Totoni, Todd A. Anderson, Sergey Maidanov. Proceedings of the 16th
 Python in Science Conference (SciPy 2017), July 10 - July 16, Austin, Texas

--- a/fft_bench.c
+++ b/fft_bench.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Intel Corporation.
+ * Copyright (c) 2017-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: MIT
  */
@@ -210,7 +210,7 @@ static const struct dtype *parse_dtype(const char *name) {
     return NULL;
 }
 
-static inline void warm_up_threads() {
+static inline void warm_up_threads(void) {
     int i;
     unsigned int *x = malloc(mkl_get_max_threads() * sizeof(int));
 
@@ -346,7 +346,7 @@ static void *randn(const struct dtype *dtype, MKL_LONG n, MKL_INT brng,
     errno = 0;
     void *x = (void *) mkl_malloc(n * dtype->size, 64);
     if (x == NULL)
-        error(1, errno, "failed to allocate %lu bytes for x", n * dtype->size);
+        error(1, errno, "failed to allocate %zu bytes for x", n * dtype->size);
     assert(x);
 
     err = vslNewStream(&stream, brng, seed);
@@ -462,22 +462,17 @@ int main(int argc, char *argv[]) {
     bool header = true, verbose = false, inplace = false, cached = false;
     bool rfft = false;
     MKL_LONG inner_loops = 16, outer_loops = 5;
-    size_t goal_outer_loops = 10;
-    double time_limit = 10.;
     size_t threads = 0;
     MKL_LONG n = 0, *strides = NULL;
 
     const char *prefix = "Native-C", *strdtype = "complex128";
     const char *problem = NULL;
     char *strsize = NULL;
-    static const char *problems[] = {0, "fft", "fft2", "fftn"};
 
 #ifdef __GNUC__
     static struct option longopts[] = {
         {"inner-loops", required_argument, NULL, 'i'},
         {"outer-loops", required_argument, NULL, 'o'},
-        {"goal-outer-loops", required_argument, NULL, 'g'},
-        {"time-limit", required_argument, NULL, 'l'},
         {"threads", required_argument, NULL, 't'},
         {"prefix", required_argument, NULL, 'p'},
         {"dtype", required_argument, NULL, 'd'},
@@ -559,12 +554,6 @@ int main(int argc, char *argv[]) {
         case 'o':
             outer_loops = intarg;
             break;
-        case 'g':
-            goal_outer_loops = intarg;
-            break;
-        case 'l':
-            time_limit = darg;
-            break;
         case 't':
             threads = intarg;
         default:
@@ -624,7 +613,7 @@ int main(int argc, char *argv[]) {
     strsize = shape_to_str(ndims, shape);
     for (i = 0; i < ndims; i++) {
         if (shape[i] < 1) {
-            error(1, 0, "given shape %s is invalid: shape[%lu] = %ld < 1\n",
+            error(1, 0, "given shape %s is invalid: shape[%zu] = %ld < 1\n",
                   strsize, i, shape[i]);
         }
     }
@@ -757,7 +746,7 @@ int main(int argc, char *argv[]) {
         time_tot += t1 - t0;
 
         times[si] = seconds_from_moment(time_tot / inner_loops);
-        printf("%s,%s,%lu,%s,%s,%s,%s,%.5g\n", prefix, problem, threads,
+        printf("%s,%s,%zu,%s,%s,%s,%s,%.5g\n", prefix, problem, threads,
                dtype->names[0], strsize, strplace, strcache, times[si]);
     }
 

--- a/fft_bench.py
+++ b/fft_bench.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2020 Intel Corporation.
+# Copyright (c) 2017-2025 Intel Corporation.
 #
 # SPDX-License-Identifier: MIT
 

--- a/moments.h
+++ b/moments.h
@@ -1,5 +1,5 @@
 /*
-    Copyright 2005-2013 Intel Corporation.  All Rights Reserved.
+    Copyright 2005-2025  (c) Intel Corporation. All Rights Reserved.
 
     The source code contained or described herein and all documents related
     to the source code ("Material") are owned by Intel Corporation or its

--- a/perf.py
+++ b/perf.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2020 Intel Corporation.
+# Copyright (c) 2017-2025 Intel Corporation.
 #
 # SPDX-License-Identifier: MIT
 

--- a/win_compile_all.bat
+++ b/win_compile_all.bat
@@ -1,7 +1,7 @@
 @ECHO off
 
-SET _MKL_DIR=C:\Program Files (x86)\IntelSWTools\compilers_and_libraries\windows\mkl
+SET _MKL_DIR=C:\Program Files (x86)\Intel\oneAPI\mkl
 
-icl /c /nologo /O3 /MD /W3 /Qstd=c99 /fp:strict /QxSSE4.2 /QaxCORE-AVX2,COMMON-AVX512 /Qopenmp -I"%_MKL_DIR%\include" /D_CRT_SECURE_NO_WARNINGS /DNDEBUG /Qmkl fft_bench.c
-icl /nologo fft_bench.obj /Fe"fft_bench.exe" /link /LIBPATH:"%_MKL_DIR%\lib\intel64_win" mkl_rt.lib
+icx /c /nologo /O3 /MD /W3 /Qstd=c99 /fp:strict /QxSSE4.2 /QaxCORE-AVX2,COMMON-AVX512 /Qopenmp -I"%_MKL_DIR%\include" /D_CRT_SECURE_NO_WARNINGS /DNDEBUG /Qmkl fft_bench.c
+icx /nologo fft_bench.obj /Fe"fft_bench.exe" /link /LIBPATH:"%_MKL_DIR%\lib\intel64_win" mkl_rt.lib
 del fft_bench.obj


### PR DESCRIPTION
In this PR, 

1) Instruction for running the benchmark is updated in `README.md`.
2) `Makefile` is update to avoid a waning generated at compile time.
3) `fft_bench.c` file is updated to remove unused variables and avoid a few warning related to formatting.
4) Copyright date is updated.
